### PR TITLE
Retry-mekanisme for sletting: maks ett retry ved ukjent feil (#13)

### DIFF
--- a/src/main/kotlin/no/nav/eux/slett/usendte/rinasaker/model/RinasakStatus.kt
+++ b/src/main/kotlin/no/nav/eux/slett/usendte/rinasaker/model/RinasakStatus.kt
@@ -22,6 +22,7 @@ data class RinasakStatus(
     val endretTidspunkt: LocalDateTime = now(),
 ) {
     enum class Status {
-        NY_SAK, DOKUMENT_SENT, TIL_SLETTING, SLETTET, KAN_IKKE_SLETTES, KORRUPT, NOT_FOUND
+        NY_SAK, DOKUMENT_SENT, TIL_SLETTING, SLETTET, KAN_IKKE_SLETTES, KORRUPT, NOT_FOUND,
+        SLETTING_FEILET_RETRY, SLETTING_FEILET
     }
 }

--- a/src/main/kotlin/no/nav/eux/slett/usendte/rinasaker/service/SlettUsendteRinasakerService.kt
+++ b/src/main/kotlin/no/nav/eux/slett/usendte/rinasaker/service/SlettUsendteRinasakerService.kt
@@ -20,8 +20,8 @@ class SlettUsendteRinasakerService(
     val log = logger {}
 
     fun slettUsendteRinasaker() {
-        repository
-            .findAllByStatus(TIL_SLETTING)
+        (repository.findAllByStatus(TIL_SLETTING) +
+            repository.findAllByStatus(SLETTING_FEILET_RETRY))
             .forEach { it.trySlett() }
     }
 
@@ -59,6 +59,17 @@ class SlettUsendteRinasakerService(
             log.info { "Rinasak status oppdatert til NOT_FOUND" }
         } catch (e: Exception) {
             log.error(e) { "Kunne ikke slette rinasak $rinasakId" }
+            when (status) {
+                TIL_SLETTING -> {
+                    repository.save(copy(status = SLETTING_FEILET_RETRY, endretTidspunkt = now()))
+                    log.info { "Rinasak status oppdatert til SLETTING_FEILET_RETRY, forsøkes igjen ved neste kjøring" }
+                }
+                SLETTING_FEILET_RETRY -> {
+                    repository.save(copy(status = SLETTING_FEILET, endretTidspunkt = now()))
+                    log.info { "Rinasak status oppdatert til SLETTING_FEILET, gir opp videre sletting" }
+                }
+                else -> log.error { "Uventet status $status ved feilet sletting av rinasak $rinasakId" }
+            }
         }
 
     fun RinasakStatus.slett() {

--- a/src/test/kotlin/no/nav/eux/slett/usendte/rinasaker/webapp/SlettUsendteRinasakerTest.kt
+++ b/src/test/kotlin/no/nav/eux/slett/usendte/rinasaker/webapp/SlettUsendteRinasakerTest.kt
@@ -44,10 +44,11 @@ class SlettUsendteRinasakerTest : AbstractTest() {
         kafkaTemplate.send("eessibasis.eux-rina-case-events-v1", kafkaRinaCase(4))
         kafkaTemplate.send("eessibasis.eux-rina-case-events-v1", kafkaRinaCase(5))
         kafkaTemplate.send("eessibasis.eux-rina-case-events-v1", kafkaRinaCase(6))
+        kafkaTemplate.send("eessibasis.eux-rina-case-events-v1", kafkaRinaCase(7))
         await untilCallTo {
             rinasakStatusRepository.findAllByStatus(NY_SAK)
         } has {
-            size == 6
+            size == 7
         }
         kafkaTemplate.send("eessibasis.eux-rina-document-events-v1", kafkaRinaDocument(1))
         kafkaTemplate.send("eessibasis.eux-rina-document-events-v1", kafkaRinaDocument(2))
@@ -57,7 +58,7 @@ class SlettUsendteRinasakerTest : AbstractTest() {
             size == 2
         }
         await untilCallTo { rinasakStatusRepository.findAllByStatus(NY_SAK) } has {
-            size == 4
+            size == 5
         }
         manipulerOpprettetTidspunkt()
         restTemplate
@@ -74,12 +75,14 @@ class SlettUsendteRinasakerTest : AbstractTest() {
         assertThat(requestBodies["/api/v1/rinasaker/4/status"]).isNull()
         assertThat(requestBodies["/api/v1/rinasaker/5/status"]).isNotNull()
         assertThat(requestBodies["/api/v1/rinasaker/6/status"]).isNotNull()
+        assertThat(requestBodies["/api/v1/rinasaker/7/status"]).isNotNull()
         assertThat(rinasakStatus(1)).isEqualTo(DOKUMENT_SENT)
         assertThat(rinasakStatus(2)).isEqualTo(DOKUMENT_SENT)
         assertThat(rinasakStatus(3)).isEqualTo(TIL_SLETTING)
         assertThat(rinasakStatus(4)).isEqualTo(NY_SAK)
         assertThat(rinasakStatus(5)).isEqualTo(KAN_IKKE_SLETTES)
         assertThat(rinasakStatus(6)).isEqualTo(TIL_SLETTING)
+        assertThat(rinasakStatus(7)).isEqualTo(TIL_SLETTING)
         restTemplate
             .exchange<Void>(
                 "/api/v1/sletteprosess/slett/execute",
@@ -90,8 +93,17 @@ class SlettUsendteRinasakerTest : AbstractTest() {
         requestBodies.forEach { println("Path: ${it.key}, body: ${it.value}") }
         assertThat(requestBodies["/api/v1/rinasaker/3"]).isNotNull()
         assertThat(requestBodies["/api/v1/rinasaker/6"]).isNotNull()
+        assertThat(requestBodies["/api/v1/rinasaker/7"]).isNotNull()
         assertThat(rinasakStatus(3)).isEqualTo(SLETTET)
         assertThat(rinasakStatus(6)).isEqualTo(NOT_FOUND)
+        assertThat(rinasakStatus(7)).isEqualTo(SLETTING_FEILET_RETRY)
+        restTemplate
+            .exchange<Void>(
+                "/api/v1/sletteprosess/slett/execute",
+                POST,
+                httpEntity()
+            )
+        assertThat(rinasakStatus(7)).isEqualTo(SLETTING_FEILET)
         manipulerEndretTidspunktForNotFound()
         requestBodies.clear()
         restTemplate
@@ -127,6 +139,10 @@ class SlettUsendteRinasakerTest : AbstractTest() {
             .findByRinasakId(6)!!
             .copy(opprettetTidspunkt = now().minusDays(32))
         rinasakStatusRepository.save(rinasakNotFound)
+        val rinasakSlettingFeiler = rinasakStatusRepository
+            .findByRinasakId(7)!!
+            .copy(opprettetTidspunkt = now().minusDays(32))
+        rinasakStatusRepository.save(rinasakSlettingFeiler)
     }
 
     fun manipulerEndretTidspunktForNotFound() {

--- a/src/test/kotlin/no/nav/eux/slett/usendte/rinasaker/webapp/mock/MockResponses.kt
+++ b/src/test/kotlin/no/nav/eux/slett/usendte/rinasaker/webapp/mock/MockResponses.kt
@@ -36,6 +36,7 @@ fun mockResponseGet(request: RecordedRequest) =
         "/api/v1/rinasaker/4/status" -> getEuxRinaTerminatorApiStatusResponseTrue()
         "/api/v1/rinasaker/5/status" -> getEuxRinaTerminatorApiStatusResponseFalse()
         "/api/v1/rinasaker/6/status" -> getEuxRinaTerminatorApiStatusResponseTrue()
+        "/api/v1/rinasaker/7/status" -> getEuxRinaTerminatorApiStatusResponseTrue()
         else -> defaultResponse()
     }
 
@@ -43,6 +44,7 @@ fun mockResponseDelete(request: RecordedRequest) =
     when (request.uriEndsWith) {
         "/api/v1/rinasaker/3" -> response204()
         "/api/v1/rinasaker/6" -> response404()
+        "/api/v1/rinasaker/7" -> response500()
         else -> defaultResponse()
     }
 

--- a/src/test/kotlin/no/nav/eux/slett/usendte/rinasaker/webapp/mock/MockResponsesCommon.kt
+++ b/src/test/kotlin/no/nav/eux/slett/usendte/rinasaker/webapp/mock/MockResponsesCommon.kt
@@ -18,3 +18,9 @@ fun response404() =
         setResponseCode(404)
         setBody("Feilet kall mot RINA: ")
     }
+
+fun response500() =
+    MockResponse().apply {
+        setResponseCode(500)
+        setBody("Internal Server Error")
+    }


### PR DESCRIPTION
Innfører to nye statuser SLETTING_FEILET_RETRY og SLETTING_FEILET for å
unngå endeløse forsøk på sletting av rinasaker som feiler med ukjent feil.

Ved første feil flyttes saken til SLETTING_FEILET_RETRY og forsøkes igjen
ved neste kjøring av slett-prosessen. Ved andre feil flyttes saken til
SLETTING_FEILET og ingen flere forsøk gjøres.

NOT_FOUND-håndtering er uendret.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
