### PR TITLE
Set endretTidspunkt when updating status to DOKUMENT_SENT

### DIFF
--- a/src/main/kotlin/no/nav/eux/slett/usendte/rinasaker/service/SlettUsendteRinasakerService.kt
+++ b/src/main/kotlin/no/nav/eux/slett/usendte/rinasaker/service/SlettUsendteRinasakerService.kt
@@ -93,7 +93,7 @@ class SlettUsendteRinasakerService(
         val rinasakStatus = repository
             .findByRinasakId(rinasakId)
             ?: rinasakStatus(rinasakId, bucType, DOKUMENT_SENT)
-        repository.save(rinasakStatus.copy(status = DOKUMENT_SENT))
+        repository.save(rinasakStatus.copy(status = DOKUMENT_SENT, endretTidspunkt = now()))
         log.info { "Dokument lagt til" }
     }
 


### PR DESCRIPTION
Closes #16

Adds `endretTidspunkt = now()` to the `copy()` call in `leggTilDokument()`, making it consistent with every other status transition in the service. Without this, DOKUMENT_SENT cases retain their original creation timestamp, causing the monthly rapport to attribute them to the wrong month.