### PR TITLE
Bump parent-pom from 2.0.4 to 2.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.nav.eux</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>2.0.4</version>
+        <version>2.0.7</version>
     </parent>
 
     <groupId>no.nav.eux.slett.usendte.rinasaker</groupId>


### PR DESCRIPTION
Bumps `no.nav.eux:parent-pom` from version 2.0.4 to 2.0.7.