### PR TITLE
chore(deps): bump parent-pom to 2.0.15, flyway to 12.9.0, checkout to v7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Calling nais deploy action for q1'
         uses: nais/deploy/actions/deploy@v2
         env:
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Calling nais deploy action for q2'
         uses: nais/deploy/actions/deploy@v2
         env:
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, deploy-q1, deploy-q2]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Calling nais deploy action for prod'
         uses: nais/deploy/actions/deploy@v2
         env:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.nav.eux</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>2.0.10</version>
+        <version>2.0.15</version>
     </parent>
 
     <groupId>no.nav.eux.slett.usendte.rinasaker</groupId>
@@ -18,7 +18,7 @@
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flyway.version>12.0.2</flyway.version>
+        <flyway.version>12.9.0</flyway.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
## Dependency bumps

- `parent-pom`: 2.0.10 → 2.0.15
- `flyway.version`: 12.0.2 → 12.9.0
- `actions/checkout`: v6 → v7 (Node 24 compatible, released 2026-06-18)